### PR TITLE
Adding energy filter num_dims check to avoid crash

### DIFF
--- a/examples/plot_minimal_example.py
+++ b/examples/plot_minimal_example.py
@@ -29,11 +29,7 @@ my_settings.inactive = 0
 my_settings.particles = 5000
 my_settings.run_mode = "fixed source"
 # Create a DT point source
-try:
-    source = openmc.IndependentSource()
-except:
-    # work with older versions of openmc
-    source = openmc.Source()
+source = openmc.IndependentSource()
 source.space = openmc.stats.Point((100, 0, 0))
 source.angle = openmc.stats.Isotropic()
 source.energy = openmc.stats.Discrete([14e6], [1])
@@ -46,8 +42,9 @@ mesh = openmc.RegularMesh().from_domain(
     dimension=[40, 40, 40],
 )
 mesh_filter = openmc.MeshFilter(mesh)
+energy_filter = openmc.EnergyFilter([0, 1e6, 2e6])
 mesh_tally_1 = openmc.Tally(name="mesh_tally")
-mesh_tally_1.filters = [mesh_filter]
+mesh_tally_1.filters = [mesh_filter, energy_filter]
 mesh_tally_1.scores = ["heating"]
 my_tallies.append(mesh_tally_1)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -215,7 +215,7 @@ def test_plot_with_energy_filters(model):
     with openmc.StatePoint(sp_filename) as statepoint:
         tally_result_1 = statepoint.get_tally(name="mesh_tally")
 
-    with pytest.raises(ValueError) as excinfo:  
+    with pytest.raises(ValueError) as excinfo:
         plot_mesh_tally(tally=tally_result_1)
     msg = (
         "An EnergyFilter was found on the tally with more "
@@ -226,7 +226,7 @@ def test_plot_with_energy_filters(model):
         "bin are unsupported"
     )
     assert str(excinfo.value) == msg
-  
+
     energy_filter = openmc.EnergyFilter([0, 2e6])
     mesh_tally_1.filters = [mesh_filter, energy_filter]
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -197,4 +197,48 @@ def test_plot_two_mesh_tallies(model):
     assert plot.get_ylim() == (-3.0, 3.5)
 
 
+def test_plot_with_energy_filters(model):
+    geometry = model.geometry
+
+    mesh = openmc.RegularMesh().from_domain(geometry, dimension=[2, 20, 30])
+    mesh_filter = openmc.MeshFilter(mesh)
+    energy_filter = openmc.EnergyFilter([0, 1e6, 2e6])
+    mesh_tally_1 = openmc.Tally(name="mesh_tally")
+    mesh_tally_1.filters = [mesh_filter, energy_filter]
+    mesh_tally_1.scores = ["heating"]
+
+    tallies = openmc.Tallies([mesh_tally_1])
+
+    model.tallies = tallies
+
+    sp_filename = model.run()
+    with openmc.StatePoint(sp_filename) as statepoint:
+        tally_result_1 = statepoint.get_tally(name="mesh_tally")
+
+    with pytest.raises(ValueError) as excinfo:  
+        plot_mesh_tally(tally=tally_result_1)
+    msg = (
+        "An EnergyFilter was found on the tally with more "
+        "than a single bin. EnergyFilter.num_bins="
+        "2. Either reduce the number "
+        "of energy bins to 1 or remove the EnergyFilter to "
+        "plot this tally. EnergyFilter with more than 1 energy "
+        "bin are unsupported"
+    )
+    assert str(excinfo.value) == msg
+  
+    energy_filter = openmc.EnergyFilter([0, 2e6])
+    mesh_tally_1.filters = [mesh_filter, energy_filter]
+
+    tallies = openmc.Tallies([mesh_tally_1])
+
+    model.tallies = tallies
+
+    sp_filename = model.run()
+    with openmc.StatePoint(sp_filename) as statepoint:
+        tally_result_1 = statepoint.get_tally(name="mesh_tally")
+
+    plot_mesh_tally(tally=tally_result_1)
+
+
 # todo catch errors when 2d mesh used and 1d axis selected for plotting'


### PR DESCRIPTION
As discussed here
https://openmc.discourse.group/t/neutron-flux-in-a-graphite-stack/3916/15

A tally with an energy filter has multiple values and there is not arg to indicate which one to plot. So for now we can check for the existance of energy filters that have more than 1 num_dims and raise a value error with a clear message to the user.